### PR TITLE
Proposed changes to address UKGovLD/registry-core #92

### DIFF
--- a/src/main/java/com/epimorphics/registry/webapi/LibReg.java
+++ b/src/main/java/com/epimorphics/registry/webapi/LibReg.java
@@ -645,6 +645,8 @@ public class LibReg extends ComponentBase implements LibPlugin {
     private void findResources(RDFNodeWrapper base, Set<RDFNodeWrapper> links) {
         if ( links.add(base) ) {
             for (PropertyValue pv : base.listProperties()) {
+            	// Include properties in the list of things to get labels for
+            	links.add(pv.getProp());
                 for (RDFNodeWrapper link : pv.getValues()) {
                     if (link.isResource() && !links.contains(link)) {
                         findResources(link, links);


### PR DESCRIPTION
I've added a line to include the property associated with an entities property value (`pv`) to the growing list of resources that will be probed for labels. This pulls 'useful' labels onto the model accessible to the velocity templates so that property labels rather than final segments can be use for labelling table entries.