### PR TITLE
Hide submitted registry items

### DIFF
--- a/src/main/java/com/epimorphics/registry/core/Description.java
+++ b/src/main/java/com/epimorphics/registry/core/Description.java
@@ -126,6 +126,15 @@ public class Description {
     public RegisterItem asRegisterItem() {
         return (RegisterItem)this;
     }
+
+    public Boolean isRegisterItem() {
+        return false;
+    }
+
+    public Boolean isEntity() {
+        return true;
+    }
+
     /**
      * Flatten versioning information
      */

--- a/src/main/java/com/epimorphics/registry/core/Register.java
+++ b/src/main/java/com/epimorphics/registry/core/Register.java
@@ -80,6 +80,10 @@ public class Register extends Description {
         }
     }
 
+    public Boolean isEntity() {
+        return false;
+    }
+
     /**
      * Fetch all the members of the register and construct an RDF view
      * according the given flags.

--- a/src/main/java/com/epimorphics/registry/core/RegisterItem.java
+++ b/src/main/java/com/epimorphics/registry/core/RegisterItem.java
@@ -176,6 +176,14 @@ public class RegisterItem extends Description {
         return Description.descriptionFrom( store.getEntity(this), store ).asRegister();
     }
 
+    public Boolean isRegisterItem() {
+        return true;
+    }
+
+    public Boolean isEntity() {
+        return false;
+    }
+
     /**
      * Takes a register item resource from a request payload, determines and checks
      * the intended URI for both it and the entity, fills in blanks on the register item,

--- a/src/test/java/com/epimorphics/registry/webapi/TestAPI.java
+++ b/src/test/java/com/epimorphics/registry/webapi/TestAPI.java
@@ -543,11 +543,23 @@ public class TestAPI extends TomcatTestBase {
         assertEquals(404, getResponse(REG1 + "/_red?status=notaccepted").getStatus());
         assertEquals(404, getResponse(REG1 + "/_red?status=invalid").getStatus());
 
+        assertEquals(200, getResponse(REG1 + "/red?status=any").getStatus());
+        assertEquals(200, getResponse(REG1 + "/red?status=accepted").getStatus());
+        assertEquals(200, getResponse(REG1 + "/red?status=valid").getStatus());
+        assertEquals(404, getResponse(REG1 + "/red?status=notaccepted").getStatus());
+        assertEquals(404, getResponse(REG1 + "/red?status=invalid").getStatus());
+
         assertEquals(200, getResponse(REG1 + "/_blue?status=any").getStatus());
         assertEquals(404, getResponse(REG1 + "/_blue?status=accepted").getStatus());
         assertEquals(404, getResponse(REG1 + "/_blue?status=valid").getStatus());
         assertEquals(200, getResponse(REG1 + "/_blue?status=notaccepted").getStatus());
         assertEquals(200, getResponse(REG1 + "/_blue?status=invalid").getStatus());
+
+        assertEquals(200, getResponse(REG1 + "/blue?status=any").getStatus());
+        assertEquals(404, getResponse(REG1 + "/blue?status=accepted").getStatus());
+        assertEquals(404, getResponse(REG1 + "/blue?status=valid").getStatus());
+        assertEquals(200, getResponse(REG1 + "/blue?status=notaccepted").getStatus());
+        assertEquals(200, getResponse(REG1 + "/blue?status=invalid").getStatus());
     }
 
     protected static final String PROXY_CONFIG = "/var/opt/ldregistry/proxy-registry.conf";

--- a/src/test/java/com/epimorphics/registry/webapi/TestAPI.java
+++ b/src/test/java/com/epimorphics/registry/webapi/TestAPI.java
@@ -137,6 +137,9 @@ public class TestAPI extends TomcatTestBase {
         // Check some status transitions
         doStatusTransitionsTest();
 
+        // Check status filtering
+        doStatusFilterTest();
+
         // Checking of legal relative URIs in registration payload
         assertEquals(400, postFileStatus("test/bad-green.ttl", REG1));
 
@@ -531,6 +534,20 @@ public class TestAPI extends TomcatTestBase {
                 RegistryVocab.predecessor,
                 ResourceFactory.createResource(REG1_URI + "/_blue") ) );
         assertEquals(204, post(REG1 + "/_blue?update&status=invalid").getStatus());
+    }
+
+    private void doStatusFilterTest() {
+        assertEquals(200, getResponse(REG1 + "/_red?status=any").getStatus());
+        assertEquals(200, getResponse(REG1 + "/_red?status=accepted").getStatus());
+        assertEquals(200, getResponse(REG1 + "/_red?status=valid").getStatus());
+        assertEquals(404, getResponse(REG1 + "/_red?status=notaccepted").getStatus());
+        assertEquals(404, getResponse(REG1 + "/_red?status=invalid").getStatus());
+
+        assertEquals(200, getResponse(REG1 + "/_blue?status=any").getStatus());
+        assertEquals(404, getResponse(REG1 + "/_blue?status=accepted").getStatus());
+        assertEquals(404, getResponse(REG1 + "/_blue?status=valid").getStatus());
+        assertEquals(200, getResponse(REG1 + "/_blue?status=notaccepted").getStatus());
+        assertEquals(200, getResponse(REG1 + "/_blue?status=invalid").getStatus());
     }
 
     protected static final String PROXY_CONFIG = "/var/opt/ldregistry/proxy-registry.conf";


### PR DESCRIPTION
Added the ability to hide a registry item and return a 404 response based on its status in item view as well as list view.
The default templates in `registry-config-base` implement status filtering based on whether the user is logged in, so that logged in users will be able to see submitted items as usual, while logged out users will not.