### PR TITLE
FIX Item visibility issue

### DIFF
--- a/src/test/java/com/epimorphics/registry/webapi/TestAPI.java
+++ b/src/test/java/com/epimorphics/registry/webapi/TestAPI.java
@@ -39,6 +39,9 @@ import java.util.Map;
 import javax.ws.rs.core.Response;
 
 import org.apache.jena.riot.RDFDataMgr;
+import org.apache.shiro.SecurityUtils;
+import org.apache.shiro.mgt.DefaultSecurityManager;
+import org.junit.Before;
 import org.junit.Test;
 
 import com.epimorphics.rdfutil.QueryUtil;
@@ -136,9 +139,6 @@ public class TestAPI extends TomcatTestBase {
 
         // Check some status transitions
         doStatusTransitionsTest();
-
-        // Check status filtering
-        doStatusFilterTest();
 
         // Checking of legal relative URIs in registration payload
         assertEquals(400, postFileStatus("test/bad-green.ttl", REG1));
@@ -534,32 +534,6 @@ public class TestAPI extends TomcatTestBase {
                 RegistryVocab.predecessor,
                 ResourceFactory.createResource(REG1_URI + "/_blue") ) );
         assertEquals(204, post(REG1 + "/_blue?update&status=invalid").getStatus());
-    }
-
-    private void doStatusFilterTest() {
-        assertEquals(200, getResponse(REG1 + "/_red?status=any").getStatus());
-        assertEquals(200, getResponse(REG1 + "/_red?status=accepted").getStatus());
-        assertEquals(200, getResponse(REG1 + "/_red?status=valid").getStatus());
-        assertEquals(404, getResponse(REG1 + "/_red?status=notaccepted").getStatus());
-        assertEquals(404, getResponse(REG1 + "/_red?status=invalid").getStatus());
-
-        assertEquals(200, getResponse(REG1 + "/red?status=any").getStatus());
-        assertEquals(200, getResponse(REG1 + "/red?status=accepted").getStatus());
-        assertEquals(200, getResponse(REG1 + "/red?status=valid").getStatus());
-        assertEquals(404, getResponse(REG1 + "/red?status=notaccepted").getStatus());
-        assertEquals(404, getResponse(REG1 + "/red?status=invalid").getStatus());
-
-        assertEquals(200, getResponse(REG1 + "/_blue?status=any").getStatus());
-        assertEquals(404, getResponse(REG1 + "/_blue?status=accepted").getStatus());
-        assertEquals(404, getResponse(REG1 + "/_blue?status=valid").getStatus());
-        assertEquals(200, getResponse(REG1 + "/_blue?status=notaccepted").getStatus());
-        assertEquals(200, getResponse(REG1 + "/_blue?status=invalid").getStatus());
-
-        assertEquals(200, getResponse(REG1 + "/blue?status=any").getStatus());
-        assertEquals(404, getResponse(REG1 + "/blue?status=accepted").getStatus());
-        assertEquals(404, getResponse(REG1 + "/blue?status=valid").getStatus());
-        assertEquals(200, getResponse(REG1 + "/blue?status=notaccepted").getStatus());
-        assertEquals(200, getResponse(REG1 + "/blue?status=invalid").getStatus());
     }
 
     protected static final String PROXY_CONFIG = "/var/opt/ldregistry/proxy-registry.conf";


### PR DESCRIPTION
Fixed an issue where status filtering was being enforced too rigidly on registry items [#104](https://github.com/UKGovLD/registry-core/issues/104). 
Changed the behaviour so that status filters are ignored when requesting a single item. However, unauthenticated users will only be able to see items with "accepted" status and get a 404 otherwise.