### PR TITLE
103 Deleting an ontology register causes other registers to appear empty

### DIFF
--- a/src/main/java/com/epimorphics/registry/store/StoreBaseImpl.java
+++ b/src/main/java/com/epimorphics/registry/store/StoreBaseImpl.java
@@ -1002,6 +1002,7 @@ public class StoreBaseImpl extends ComponentBase implements StoreAPI {
     }
 
     private void addReferencesTo(StreamRDF accumulator, Resource root) {
+        if (root == null) return;
         emitAll(accumulator, getDefaultModel().listStatements(null, null, root) );
     }
     

--- a/src/main/java/com/epimorphics/registry/store/StoreBaseImpl.java
+++ b/src/main/java/com/epimorphics/registry/store/StoreBaseImpl.java
@@ -935,6 +935,7 @@ public class StoreBaseImpl extends ComponentBase implements StoreAPI {
             if ( ! check.hasNext()) {
                 // No references so delete
                 graphs.addAll( scanAllVersions(entity, toModel(toDelete), null) );
+                emitAll(toModel(toDelete), getDefaultModel().listStatements(null, RegistryVocab.subregister, entity));
             } else {
                 check.close();
             }

--- a/src/main/java/com/epimorphics/registry/store/StoreBaseImpl.java
+++ b/src/main/java/com/epimorphics/registry/store/StoreBaseImpl.java
@@ -999,7 +999,6 @@ public class StoreBaseImpl extends ComponentBase implements StoreAPI {
     
     private void addRefClosure(StreamRDF accumulator, Resource root) {
         if (root == null) return;
-        emitAll(accumulator, getDefaultModel().listStatements(null, null, root) );
         emitAll(accumulator, Closure.closure(root.inModel(getDefaultModel()), false).listStatements() );
     }
     


### PR DESCRIPTION
Fixed the bug raised in this [issue](https://github.com/UKGovLD/registry-core/issues/103).

Deleting an entity would cause all of the triples whose object is that entity to be deleted. Changed the behaviour so that only `reg:subRegister` triples would be deleted to maintain integrity. Triples in other registers referencing the deleted entity should not be affected.

Note this change also affects the "export" functionality, by omitting triples that reference the exported item (unless they appear elsewhere in the tree).