### PR TITLE
Message file location

### DIFF
--- a/src/main/java/com/epimorphics/registry/core/RegistryDirBootstrap.java
+++ b/src/main/java/com/epimorphics/registry/core/RegistryDirBootstrap.java
@@ -49,7 +49,7 @@ public class RegistryDirBootstrap implements ServletContextListener {
     public static final String ROOT_DIR_PARAM = "registry-file-root";
 
     String filebase;
-    String fileRoot;
+    public static String fileRoot;
 
     @Override
     public void contextInitialized(ServletContextEvent sce) {

--- a/src/main/java/com/epimorphics/registry/language/message/FileMessageManager.java
+++ b/src/main/java/com/epimorphics/registry/language/message/FileMessageManager.java
@@ -1,5 +1,6 @@
 package com.epimorphics.registry.language.message;
 
+import com.epimorphics.registry.core.RegistryDirBootstrap;
 import com.epimorphics.registry.language.MessagesProperties;
 import com.epimorphics.util.EpiException;
 import org.apache.commons.io.filefilter.SuffixFileFilter;
@@ -20,7 +21,7 @@ public class FileMessageManager implements MessageManager {
     private final Map<String, Messages> messagesByLang;
 
     public FileMessageManager() {
-        this("/opt/ldregistry/config/language/messages");
+        this(RegistryDirBootstrap.fileRoot + "config/language/messages");
     }
 
     FileMessageManager(String msgsLoc) {


### PR DESCRIPTION
Locate UI messages in configured registry root dir.
This approach is not very elegant but there is currently no way for component instances to dynamically obtain the registry root directory.