### PR TITLE
Partial fix for 404 on missing entity

### DIFF
--- a/src/main/java/com/epimorphics/registry/RegRun.java
+++ b/src/main/java/com/epimorphics/registry/RegRun.java
@@ -45,8 +45,8 @@ public class RegRun {
 
         tomcat.setBaseDir(".");
 
-        // String contextPath = "/registry";  // Use for local testing without nginx/apache front end reverse proxy
-        String contextPath = "/ldregistry";
+        String contextPath = "/registry";  // Use for local testing without nginx/apache front end reverse proxy
+        // String contextPath = "/ldregistry";
 
         File rootF = new File(root);
         if (!rootF.exists()) {

--- a/src/main/java/com/epimorphics/registry/commands/CommandRead.java
+++ b/src/main/java/com/epimorphics/registry/commands/CommandRead.java
@@ -203,6 +203,20 @@ public class CommandRead extends Command {
             } else if (ri.getEntity() != null) {
                 m.add( ri.getEntity().getModel() );
             }
+
+            // Full solution here would also apply this to the case where entityWithMetadata is set
+            // that's why the check is inject at this point.
+            // That full solution currently disabled due to test case issues.
+//            if (graphEntity || entityWithMetadata) {
+            if (graphEntity ) {
+                // Validate that the graph contains a matching entity definition with a type property.
+                // For both plain and graph registered entities this is enforced at registration time.
+                // If this is an external entity then the graph will not contain a matching root resource
+                // and we prefer to return a 404 in that case.
+                if ( ! m.getResource(target).hasProperty(RDF.type) ) {
+                    throw new NotFoundException();
+                }
+            }
         }
         
         List<Resource> members = (paged) ? new ArrayList<Resource>(length) : new ArrayList<Resource>() ;

--- a/test/expected/reference_red.ttl
+++ b/test/expected/reference_red.ttl
@@ -1,0 +1,19 @@
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl:  <http://www.w3.org/2002/07/owl#> .
+@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+@prefix dct:  <http://purl.org/dc/terms/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+@prefix reg:  <http://purl.org/linked-data/registry#> .
+
+<_reference> a reg:RegisterItem;
+    reg:definition [
+       reg:entity  <http://location.data.gov.uk/reg1/red>;
+    ]
+.
+
+<http://location.data.gov.uk/reg1/red> a skos:Concept;
+    rdfs:label "red"
+    .
+

--- a/test/reference.ttl
+++ b/test/reference.ttl
@@ -1,0 +1,19 @@
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl:  <http://www.w3.org/2002/07/owl#> .
+@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+@prefix dct:  <http://purl.org/dc/terms/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+@prefix reg:  <http://purl.org/linked-data/registry#> .
+
+<_reference> a reg:RegisterItem;
+    reg:definition [
+       reg:entity  <http://location.data.gov.uk/reg1/red>;
+    ] 
+.
+
+<http://location.data.gov.uk/reg1/red> a skos:Concept;
+    rdfs:label "red"
+.
+

--- a/test/reg4.ttl
+++ b/test/reg4.ttl
@@ -1,0 +1,25 @@
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl:  <http://www.w3.org/2002/07/owl#> .
+@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+@prefix dct:  <http://purl.org/dc/terms/> .
+@prefix dc:   <http://purl.org/dc/elements/1.1/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix version:  <http://purl.org/linked-data/version#> .
+@prefix ldp:  <http://www.w3.org/ns/ldp#> .
+@prefix ssd:  <http://www.w3.org/ns/sparql-service-description#> .
+@prefix vs:   <http://www.w3.org/2003/06/sw-vocab-status/ns#> .
+@prefix void: <http://rdfs.org/ns/void#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+
+@prefix reg:  <http://purl.org/linked-data/registry#> .
+
+<reg4> a reg:Register, skos:Collection ;
+    ldp:membershipPredicate skos:member;
+    rdfs:label "register 4"@en;
+    dct:description "Example register 4"@en;
+    reg:owner      <http://example.com/department> ;
+    reg:manager   <http://example.com/registryManagementLtd>
+.
+


### PR DESCRIPTION
There are two cases to handle.
This patch handles the case where the request has no flags
by validating entity graph to check external refs.

If the request is `_view=with_metadata` then we also have to run
a similar check. However, a number of existing test cases
currently fail because they (accidentally) use external items.

Partially addresses: #159