### PR TITLE
Update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,7 @@
      <dependency>
       <groupId>org.apache.shiro</groupId>
       <artifactId>shiro-core</artifactId>
-      <version>1.8.0</version>
+      <version>1.9.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.shiro</groupId>
@@ -192,7 +192,7 @@
     <dependency>
       <groupId>org.apache.derby</groupId>
       <artifactId>derby</artifactId>
-      <version>10.12.1.1</version>
+      <version>10.14.2.0</version>
     </dependency>
     <dependency>
       <groupId>org.fusesource.stompjms</groupId>

--- a/src/main/java/com/epimorphics/registry/RegRun.java
+++ b/src/main/java/com/epimorphics/registry/RegRun.java
@@ -45,8 +45,8 @@ public class RegRun {
 
         tomcat.setBaseDir(".");
 
-        // String contextPath = "/registry";  // Use for local testing without nginx/apache front end reverse proxy
-        String contextPath = "/ldregistry";
+        String contextPath = "/registry";  // Use for local testing without nginx/apache front end reverse proxy
+        // String contextPath = "/ldregistry";
 
         File rootF = new File(root);
         if (!rootF.exists()) {


### PR DESCRIPTION
Addresses depenabot vulnerabilities.

Tested against local copies of user password store, version update appears safe and does not break existing account logins.