### PR TITLE
Fix CSV roundtrip datatype and language literals with apostrophes.

### DIFF
--- a/src/main/java/com/epimorphics/registry/csv/RDFCSVUtil.java
+++ b/src/main/java/com/epimorphics/registry/csv/RDFCSVUtil.java
@@ -86,10 +86,10 @@ public class RDFCSVUtil {
                             return l.getLexicalForm();   // Treat numbers as plain, means round trip isn't safe TODO Review this 
                         }
                     }
-                    return String.format("'%s'^^%s", lex, asPrefixOrURI(dt, prefixes));
+                    return String.format("'%s'^^%s", lex.replace("'", "\\'"), asPrefixOrURI(dt, prefixes));
                 }
             } else {
-                return String.format("'%s'@%s", lex, l.getLanguage());
+                return String.format("'%s'@%s", lex.replace("'", "\\'"), l.getLanguage());
             }
         }
     }

--- a/test/csv/testResource.csv
+++ b/test/csv/testResource.csv
@@ -1,3 +1,3 @@
-@dummy,@id,eg:blank,eg:decimal,eg:multiline,eg:number,eg:string,eg:typed,rdf:type,rdfs:label
-"",<r>,[rdfs:label 'blank'; eg:number 1; ],3.14,"a longer
-string",42,"a plain ' "" string",'abc'^^eg:type,eg:Thing,'a thing'@en
+@dummy,@id,eg:blank,eg:decimal,eg:markup,eg:multiline,eg:number,eg:place,eg:string,eg:typed,rdf:type,rdfs:label
+"",<r>,[rdfs:label 'blank'; eg:number 1; ],3.14,"'<span class=""place"">King\'s Lynn</span>'^^rdf:HTML","a longer
+string",42,'King\'s Lynn'@en,"a plain ' "" string",'abc'^^eg:type,eg:Thing,'a thing'@en

--- a/test/csv/testResource.ttl
+++ b/test/csv/testResource.ttl
@@ -16,4 +16,6 @@
 string""";
     eg:typed "abc"^^eg:type;
     eg:blank [eg:number 1; rdfs:label "blank"];
+    eg:place "King's Lynn"@en;
+    eg:markup """<span class="place">King's Lynn</span>"""^^rdf:HTML
     .


### PR DESCRIPTION
Add two test statements for datatype and language literals with apostrophes. Update the expected CSV to include backslash escapes. Escape any apostrophes when writing language and datatype literals.

Closes #142 