### PR TITLE
Deal with Unicode BOM in input CSV

### DIFF
--- a/src/main/java/com/epimorphics/registry/csv/CSVRDFReader.java
+++ b/src/main/java/com/epimorphics/registry/csv/CSVRDFReader.java
@@ -24,6 +24,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.commons.io.input.BOMInputStream;
 import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.riot.RDFLanguages;
 
@@ -54,7 +55,7 @@ public class CSVRDFReader {
     
     public CSVRDFReader(InputStream ins, PrefixMapping prefixes) {
         reader = new CSVReader(
-                    new InputStreamReader(ins, StandardCharsets.UTF_8), 
+                    new InputStreamReader(new BOMInputStream(ins), StandardCharsets.UTF_8), 
                     ',', '"', CSVParser.NULL_CHARACTER );
         this.prefixes = prefixes;
         try {

--- a/src/test/java/com/epimorphics/registry/csv/TestCSVSupport.java
+++ b/src/test/java/com/epimorphics/registry/csv/TestCSVSupport.java
@@ -144,6 +144,11 @@ public class TestCSVSupport {
         
     }
     
+    @Test
+    public void testBOMRead() throws IOException {
+        doTestRDFRead("test/csv/read-bom.csv", "test/csv/read-bom-expected.ttl");
+    }
+    
     private void doTestRDFRead(String source, String expected) throws IOException {
         Model prefixes = ModelFactory.createDefaultModel();
         prefixes.setNsPrefix("eg", "http://localhost/def/");

--- a/test/csv/read-bom-expected.ttl
+++ b/test/csv/read-bom-expected.ttl
@@ -1,0 +1,4 @@
+@prefix eg:     <http://localhost/def/> .
+
+<http://localhost/test/a>
+        eg:test  "café"@fr .

--- a/test/csv/read-bom.csv
+++ b/test/csv/read-bom.csv
@@ -1,0 +1,2 @@
+﻿@id,eg:test
+<a>,'café'@fr


### PR DESCRIPTION
Fix: CSV with BOM

Wrap with Apache Commons IO BOMInputStream.

Test:

Add a CSV with an initial UTF-8 byte-order mark, EF BB BF, as well as a UTF-8 char.
Add the expected RDF in Turtle.
Add a test to read the CSV and check against the expected result.