### PR TITLE
Improve XSS support

### DIFF
--- a/src/main/java/com/epimorphics/registry/webapi/LibReg.java
+++ b/src/main/java/com/epimorphics/registry/webapi/LibReg.java
@@ -92,7 +92,14 @@ public class LibReg extends ComponentBase implements LibPlugin {
      * Escape user input to prevent xss scripting in URL hrefs and form parameter attributes
      */
     public String xssCleanURI(String uri) {
-        return Encode.forHtmlAttribute(uri);
+        return Encode.forUriComponent(uri);
+    }
+
+    /**
+     * Escape user input to prevent xss scripting in HTML body text
+     */
+    public String xssCleanHTML(String text) {
+        return Encode.forHtml(text);
     }
 
     /**

--- a/src/main/java/com/epimorphics/registry/webapi/LibReg.java
+++ b/src/main/java/com/epimorphics/registry/webapi/LibReg.java
@@ -103,6 +103,13 @@ public class LibReg extends ComponentBase implements LibPlugin {
     }
 
     /**
+     * Escape user input to prevent xss scripting in HTML attribute
+     */
+    public String xssCleanHTMLAtribute(String text) {
+        return Encode.forHtmlAttribute(text);
+    }
+
+    /**
      * Encodes a string to be embedded in Javascript.
      * @param input A string potentially containing Javascript or HTML syntax, eg. quotes, script tags.
      * @return A sanitised version of the given input.


### PR DESCRIPTION
- escaping for URI elements (like return URL) separated from
- escaping for elements included directly in HTML body

Partially addresses #181 