### PR TITLE
Add json logger dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,7 @@
     <tomcat.version>7.0.107</tomcat.version>
     <lib.version>3.1.2</lib.version>
     <shiro.version>1.11.0</shiro.version>
+    <log4j.version>2.20.0</log4j.version>
   </properties>
 
   <dependencies>
@@ -106,12 +107,17 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.17.1</version>
+      <version>${log4j.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-1.2-api</artifactId>
-      <version>2.14.1</version>
+      <version>${log4j.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-layout-template-json</artifactId>
+      <version>${log4j.version}</version>
     </dependency>
     <dependency>
       <groupId>com.epimorphics</groupId>


### PR DESCRIPTION
In ELK/EFK style production environments it is convenient to be able to log in json format.

This adds a templatable json logger as a dependency so that structured logging can be enabled just through configuration (overriding the log4j2.xml) without having to build a custom war.

Inclusion of the dependency should not affect or change existing logging and default format.