### PR TITLE
Bump appbase to improve velocity logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <oltu.oauth2.version>1.0.2</oltu.oauth2.version>
     <jersey.version>2.21</jersey.version>
-    <appbase.version>3.1.3</appbase.version>
+    <appbase.version>3.1.4</appbase.version>
     <jena.version>3.9.0</jena.version>
     <fuseki.version>3.9.0</fuseki.version>
     <tomcat.version>7.0.107</tomcat.version>


### PR DESCRIPTION
Clients disconnecting during render were causing extensive stack traces. These cases are not caught and logged as simple warnings.