### PR TITLE
Support disabling RDF/XML abbrev form

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
     <jena.version>3.9.0</jena.version>
     <fuseki.version>3.9.0</fuseki.version>
     <tomcat.version>7.0.107</tomcat.version>
-    <lib.version>3.1.2</lib.version>
+    <lib.version>3.1.3</lib.version>
     <shiro.version>1.12.0</shiro.version>
     <log4j.version>2.20.0</log4j.version>
   </properties>

--- a/src/main/java/com/epimorphics/registry/core/Registry.java
+++ b/src/main/java/com/epimorphics/registry/core/Registry.java
@@ -42,6 +42,7 @@ import com.epimorphics.registry.vocab.RegistryVocab;
 import com.epimorphics.registry.webapi.facets.FacetService;
 import com.epimorphics.util.EpiException;
 import com.epimorphics.util.FileUtil;
+import com.epimorphics.webapi.marshalling.RDFXMLMarshaller;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.util.FileUtils;
@@ -119,6 +120,7 @@ public class Registry extends ComponentBase implements Startup, Shutdown {
     protected RequestLogger requestLogger;
     protected boolean cacheRegisters = false;
     protected LanguageManager languageManager;
+    protected boolean useAbbrevXML = true;
     
     public void setBaseUri(String uri) {
         baseURI = uri;
@@ -229,6 +231,14 @@ public class Registry extends ComponentBase implements Startup, Shutdown {
         return languageManager;
     }
 
+    public void setUseAbbrevXML(boolean useAbbrevXML) {
+        this.useAbbrevXML = useAbbrevXML;
+    }
+
+    public boolean isUseAbbrevXML() {
+        return useAbbrevXML;
+    }
+
     @Override
     public void startup(App app) {
         super.startup(app);
@@ -303,6 +313,9 @@ public class Registry extends ComponentBase implements Startup, Shutdown {
         } else {
             log.warn("No backup service configured");
         }
+
+        // Global override of RDF/XML serialization format
+        RDFXMLMarshaller.setUseAbbreviatedWriter(useAbbrevXML);
     }
 
     /**


### PR DESCRIPTION
Defaults to existing user of RDF/XML-ABRREV writer but can configure override in app.conf by setting registry.useAbbrevXML to false

Uses extension to lib: https://github.com/epimorphics/lib/commit/9d499549204ae6ca6a7da2980f8847400f287334

Closes: #190